### PR TITLE
Streamline Quickstart

### DIFF
--- a/how-to-contribute/quickstart-for-newcomers.md
+++ b/how-to-contribute/quickstart-for-newcomers.md
@@ -1,29 +1,22 @@
 # A Quick Start Guide for Newcomers
-- **Mailing List**: https://lists.linuxfoundation.org/mailman/listinfo/chaoss
-- **Newsletter on the Web**: https://chaoss.community/news/ 
 
-There are several quick ways designed to meet, greet, encourage, and mentor newcomers to the CHAOSS Project. 
+There are several quick ways designed to meet, greet, encourage, and mentor newcomers to the CHAOSS Project. We recommend you:
 
-### CHAOSS Office Hours
+### 1. Join the CHAOSS Slack
+We have a Slack Channel! And so many working group focused channels within it. BUT, we've reserved one ESPECIALLY for newcomers, and our community is highly responsive within it. 
+This is the [Slack channel](https://join.slack.com/t/chaoss-workspace/shared_invite/zt-1fah5gu35-5oUQEPT32O2Zt~3MFVNMlw). 
+And THIS is the channel within a channel, called "#newcomers" where you'll be welcomed!  [Newcomers #office-hours channel in the CHAOSS Slack](https://chaoss-workspace.slack.com/archives/C0207C3RETX)
+
+### 2. Attend CHAOSS Office Hours
 Every week on **Tuesday**, we have an office hours intended to make it easy for you to ask questions, and find your place in the project with a supportive, experienced CHAOSS maintainer. 
 
 You can join these hours from 9am - 10am (USA Central Time) through zoom channel: https://zoom.us/my/chaoss
 
-Aside from office hours, you are welcomed to attend other CHAOSS working group meetings through the same zoom channel, [click here](https://calendar.google.com/calendar/u/0/r?cid=j9f60skdd67938kvgl0udgqjqs@group.calendar.google.com) to subscribe CHAOSS meeting calender!
-
-### CHAOSS Monthly Onboarding Call
+### 3. Attend a CHAOSS Monthly Onboarding Call
 Every first **Wednesday** of the Month, we run a Welcome to CHAOSS call for newcomers talking about the different working groups and projects in CHAOSS. 
 
-You can join this call from 11am - 12pm (USA Central Time) through our zoom channel: https://zoom.us/my/chaoss
+You can join this call from 11am - 12pm (USA Central Time) through our zoom channel: https://zoom.us/my/chaoss.
 
+If you can't make this meeting, you can get an overview of CHAOSS by watching a recording of one of the previous [Onboarding Calls](https://youtu.be/MY960Aj4MWI).
 
-### CHAOSS Slack
-We have a Slack Channel! And so many working group focused channels within it. BUT, we've reserved one ESPECIALLY for newcomers, and our community is highly responsive within it. 
-This is the [Slack channel](https://chaoss-workspace.slack.com/join/shared_invite/zt-dqeab4ab-4XrH51rc4y_WXjN~uI~6rA#/). 
-And THIS is the channel within a channel, called "#office-hours" where you'll be welcomed!  [Newcomers #office-hours channel in the CHAOSS Slack](https://chaoss-workspace.slack.com/archives/C0207C3RETX)
-
-
-### Augur Workshop
-Augur software has regular workshops to help you learn how to see what CHAOSS metrics show you about the projects you care about. You can learn about the date's and times by signing up for our mailing list/newsletter! We send one out Newsletters every week thanks to the dedication of our Community Manager, Elizabeth Barron!
-
-
+Once you've done these three things, you're ready to start participating more actively in CHAOSS! 


### PR DESCRIPTION
Based on conversations in the [DEI working group ](https://docs.google.com/document/d/1MzDk84BL7FfHDxbFxJz39M72V2Hfc5Y6oCPhOl6woxo/edit#heading=h.tdkbppxyuyyl) and Community Calls, we decided that we wanted to streamline the Quickstart and identify three steps a newcomer can take to get acquainted with CHAOSS. These are the three we identified:

- Join general Slack
- Join Office Hours
- Join Monthly Onboarding (or watch a recording)

I'd like to move some of the info that was previously in this Quickstart into maybe a new doc called "Next Steps: Participating in CHAOSS" or something like that, as we shift to more of a learning path for our contributor funnel. The next stage would be "Participating," as we [discussed in the DEI working group](https://docs.google.com/document/d/1MzDk84BL7FfHDxbFxJz39M72V2Hfc5Y6oCPhOl6woxo/edit#heading=h.tdkbppxyuyyl).

Signed-off-by: Elizabeth Barron <elizabeth@naramore.net>