### PR TITLE
Adding disclaimer

### DIFF
--- a/community-initiatives-and-working-groups/Working-Groups/README.md
+++ b/community-initiatives-and-working-groups/Working-Groups/README.md
@@ -1,3 +1,5 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
 
 # CHAOSS Working Groups
 

--- a/community-initiatives-and-working-groups/Working-Groups/metrics-commitee.md
+++ b/community-initiatives-and-working-groups/Working-Groups/metrics-commitee.md
@@ -1,4 +1,6 @@
 
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
 # Metrics Approval Process
 
 ## 👥 CHAOSS Metrics Committee

--- a/community-initiatives-and-working-groups/Working-Groups/metrics-faq.md
+++ b/community-initiatives-and-working-groups/Working-Groups/metrics-faq.md
@@ -1,3 +1,5 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
 # Metrics FAQ
 
 ## **When are CHAOSS Metrics Released in English?**

--- a/community-initiatives-and-working-groups/Working-Groups/metrics-releases.md
+++ b/community-initiatives-and-working-groups/Working-Groups/metrics-releases.md
@@ -1,3 +1,5 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
 
 # Releases
 

--- a/community-initiatives-and-working-groups/Working-Groups/metrics-translation.md
+++ b/community-initiatives-and-working-groups/Working-Groups/metrics-translation.md
@@ -1,3 +1,5 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
 
 # Guidelines for Metrics Translation
 

--- a/community-initiatives-and-working-groups/Working-Groups/working-groups-repository-structure.md
+++ b/community-initiatives-and-working-groups/Working-Groups/working-groups-repository-structure.md
@@ -1,3 +1,5 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
 
 # Working Groups Repository Structure
 

--- a/community-initiatives-and-working-groups/community-initiatives/chaoss-slack-bot.md
+++ b/community-initiatives-and-working-groups/community-initiatives/chaoss-slack-bot.md
@@ -1,3 +1,5 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
 # CHAOSS SLACK BOT
 
 ## About

--- a/community-initiatives-and-working-groups/community-initiatives/dei-badging/README.md
+++ b/community-initiatives-and-working-groups/community-initiatives/dei-badging/README.md
@@ -1,3 +1,5 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
 # Overview of the DEI Badging
 
 ## About

--- a/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/apply-for-a-badge/README.md
+++ b/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/apply-for-a-badge/README.md
@@ -1,3 +1,5 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
 # Apply for a badge
 
 We are planning to provide D&I badges for **technical events** and **open-source projects**. While currently, we only support D&I badge applications for **events.** Project applications will be covered in later versions.

--- a/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/apply-for-a-badge/apply-for-in-person-event.md
+++ b/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/apply-for-a-badge/apply-for-in-person-event.md
@@ -1,3 +1,9 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
+
+
+
+
 # Apply for an In-Person Event
 
 The D&I badging application is submitted through a web form to provide information and measurements on how an event achieves diversity and inclusion practices. All initial judgments from reviewers are made according to the form, so please do your best with it, make sure to fill out all the fields.

--- a/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/apply-for-a-badge/apply-for-virtual-event.md
+++ b/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/apply-for-a-badge/apply-for-virtual-event.md
@@ -1,3 +1,7 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
+
+
 # Apply for a Virtual Event
 
 We make one distinction between virtual events and in-person events. The Virtual Event does not support the [Family Friendliness](https://chaoss.community/metric-family-friendliness/) metric because this is not currently a concern for virtual events.

--- a/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/dei-badging-code-of-conduct.md
+++ b/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/dei-badging-code-of-conduct.md
@@ -1,3 +1,6 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
+
 # DEI Badging Code of Conduct
 
 ## Pledge

--- a/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/how-to-contribute.md
+++ b/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/how-to-contribute.md
@@ -1,3 +1,6 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
+
 # How to contribute
 
 ### Connect

--- a/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/reviewing/README.md
+++ b/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/reviewing/README.md
@@ -1,3 +1,5 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
 # Reviewing for CHAOSS
 
 ## Introduction

--- a/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/reviewing/apply-to-review.md
+++ b/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/reviewing/apply-to-review.md
@@ -1,3 +1,6 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
+
 # Apply to Review
 
 This page contains information on how to become a reviewer of the D&I badging program. To review submissions for D&I badging, you need to sign up as a reviewer first. The best way to start is with our sign-up form!

--- a/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/reviewing/conflict-of-interest-policy.md
+++ b/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/reviewing/conflict-of-interest-policy.md
@@ -1,3 +1,7 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
+
+
 # Conflict of Interest Policy
 
 ### CHAOSS D&I Badging Conflict of Interest Policy

--- a/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/reviewing/the-review-process.md
+++ b/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/reviewing/the-review-process.md
@@ -1,3 +1,7 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
+
+
 # The Review Process
 
 This page contains information about going through the review process, especially about how a reviewer could work with the Review Checklist and collect the information required for the Review Checklist criteria.

--- a/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/roles-and-responsibility/README.md
+++ b/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/roles-and-responsibility/README.md
@@ -1,3 +1,7 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
+
+
 # DEI Badging Roles
 
 ## Roles

--- a/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/roles-and-responsibility/applicant.md
+++ b/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/roles-and-responsibility/applicant.md
@@ -1,3 +1,7 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
+
+
 # Applicant
 
 ## Responsibilities

--- a/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/roles-and-responsibility/maintainer.md
+++ b/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/roles-and-responsibility/maintainer.md
@@ -1,3 +1,7 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
+
+
 # Maintainer
 
 ## Responsibilities

--- a/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/roles-and-responsibility/moderator.md
+++ b/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/roles-and-responsibility/moderator.md
@@ -1,3 +1,7 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
+
+
 # Moderator
 
 ## Responsibilities

--- a/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/roles-and-responsibility/reviewer.md
+++ b/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/roles-and-responsibility/reviewer.md
@@ -1,3 +1,7 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
+
+
 # Reviewer
 
 ## Responsibilities

--- a/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/the-badging-bot.md
+++ b/community-initiatives-and-working-groups/community-initiatives/dei-badging/event-badging/the-badging-bot.md
@@ -1,3 +1,6 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
+
 # The badging-bot
 
 ## Command & Functionality

--- a/community-initiatives-and-working-groups/community-initiatives/dei-badging/project-badging/DEI.md
+++ b/community-initiatives-and-working-groups/community-initiatives/dei-badging/project-badging/DEI.md
@@ -1,3 +1,5 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
 # Centering Diversity, Equity, and Inclusion in -- name of your project --
 
 This document demonstrates how we in -- name of your project -- are committed to centering diversity, equity, and inclusion in the work that we do. The following are four CHAOSS DEI metrics and how we address them in the -- name of your project --. 

--- a/community-initiatives-and-working-groups/community-initiatives/dei-badging/project-badging/guidelines.md
+++ b/community-initiatives-and-working-groups/community-initiatives/dei-badging/project-badging/guidelines.md
@@ -1,3 +1,5 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
 # CHAOSS Project Badging Submission Guidelines
 
 1. Make sure all the [requirements](./requirements.md) are fulfilled before initiating a CHAOSS Project Badging application.

--- a/community-initiatives-and-working-groups/community-initiatives/dei-badging/project-badging/requirements.md
+++ b/community-initiatives-and-working-groups/community-initiatives/dei-badging/project-badging/requirements.md
@@ -1,3 +1,5 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
 # CHAOSS Badging Project submission requirements
 
 ## Project status requirements

--- a/community-initiatives-and-working-groups/community-initiatives/the-mars-project.md
+++ b/community-initiatives-and-working-groups/community-initiatives/the-mars-project.md
@@ -1,3 +1,5 @@
+# **This page is no longer part of the CHAOSS Knowledge Base. Please update any links that may be associated with this page as this page and this statement will be removed at the start of 2024.**
+
 # M.A.R.S. Project
 
 ## About


### PR DESCRIPTION
Adding disclaimer to community initiatives and working group folder and its subfolders that this and all subfolders will be deleted in the future as the needed content is moved to chaoss-groups folder and is already live on the website.

Refer PR https://github.com/chaoss/community/pull/538


Signed-off-by: Vinod K. Ahuja <vahuja@unomaha.edu>