### PR TITLE
Remove Data Statement from Metrics Template

### DIFF
--- a/community-templates/metric-template.md
+++ b/community-templates/metric-template.md
@@ -39,6 +39,3 @@ Blog posts, websites, academic papers, or books that mention the metric and prov
 ## Known Contributors
 List of people who would like to be mentioned as contributors to this metric.
 
-## Data Ethics Statement
-The usage and dissemination of health metrics may lead to privacy violations. Organizations may be exposed to risks. These risks may flow from compliance with the GDPR in the EU, with state law in the US, or with other laws. There may also be contractual risks flowing from terms of service for data providers such as GitHub and GitLab. The usage of metrics must be examined for risk and potential data ethics problems. Please see [CHAOSS Data Ethics document](https://github.com/chaoss/community/blob/main/data-use-statement.md) for additional guidance.
-


### PR DESCRIPTION
This removes the Data Use Statement section, as it has been replaced with a common block we add when publishing the metrics page in Wordpress.

Signed-off-by: Elizabeth Barron <elizabeth@naramore.net>