### PR TITLE
Update 02-chaosscast-episode-checklist.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-chaosscast-episode-checklist.md
+++ b/.github/ISSUE_TEMPLATE/02-chaosscast-episode-checklist.md
@@ -46,7 +46,6 @@ Please get approval from the CHAOSScast facilitator before creating a CHAOSScast
   * Enjoy
 * After the podcast is recorded:
   * [ ] **Action:** Go to Zoom and get the link to the recording
-  * [ ] **Action:** Set the recording to not expire
   * [ ] **Action:** Email the link to Paul Bahr from Peachtree Sound
 
 ### Publishing an episode \(~30-40 min\)


### PR DESCRIPTION
Removed "recording set to expire" checkbox as not required as the editing service usually edits much quicker than the recording would expire.