### PR TITLE
Proposing a built in action for logging contributions from an issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-Contribution.yaml
+++ b/.github/ISSUE_TEMPLATE/01-Contribution.yaml
@@ -1,0 +1,58 @@
+name: CHAOSS Contribution
+title: "[Project]: NAME"
+description: Use this template to register a new CHAOSS Contribution
+labels: ['contribution']
+
+body:
+  - type: markdown
+    attributes:
+      value: | 
+        CHAOSS Welcomes all contributions! Here is where you can claim credit!
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Task Completed
+
+  - type: input
+    attributes:
+      label: Specify Area of Project (1 - 5 words)
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Date of Completion 
+      description: Enter the date you completed the task (e.g., 2024-07-12). 
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Specify the type of contribution (e.g., Documentation, Community Building, etc.).
+      options:
+        - Writing Code not submitted in a PR
+        - Reviewing Code
+        - Bug Triaging
+        - Quality Assurance and Testing
+        - Security-Related Activities
+        - Localization/L10N and Translation
+        - Event Organization
+        - Documentation Authorship
+        - Community Building and Management
+        - Teaching and Tutorial Building
+        - Troubleshooting and Support
+        - Creative Work and Design
+        - User Interface, User Experience, and Accessibility
+        - Social Media Management
+        - User Support and Answering Questions
+        - Writing Articles
+        - Public Relations
+        - Speaking at Events about CHAOSS
+        - Marketing and Campaign Advocacy
+        - Website Development
+        - Legal Counsel
+        - Financial Management
+        - Project Management
+    validations:
+      required: true

--- a/.github/workflows/new-workflow.yml
+++ b/.github/workflows/new-workflow.yml
@@ -1,0 +1,40 @@
+name: Update Markdown on Contribution Issue
+
+on:
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  update-markdown:
+    if: |
+      contains(github.event.issue.labels.*.name, 'contribution') &&
+      (github.event.action == 'opened' || github.event.action == 'labeled')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4  # Updated to v4 for Node.js 20 support
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4  # Updated to v4 for Node.js 20 support
+        with:
+          node-version: '20'  # Use Node.js 20
+
+      - name: Print Node.js version
+        run: node -v
+
+      - name: Install @actions/core and @actions/github
+        run: npm install @actions/core @actions/github
+
+      - name: Update markdown file
+        run: node log-contribution.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit and Push changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add -f community-contributions.md
+          git commit -m 'Update markdown file with new contribution issue' || echo "Nothing to commit"
+          git pull --rebase
+          git push

--- a/log-contribution.js
+++ b/log-contribution.js
@@ -1,0 +1,81 @@
+const fs = require('fs');
+const core = require('@actions/core');
+const github = require('@actions/github');
+
+(async () => {
+  try {
+    const token = process.env.GITHUB_TOKEN;
+    const octokit = github.getOctokit(token);
+
+    const { context } = github;
+    const { issue } = context.payload;
+
+    if (issue.labels.some(label => label.name === 'contribution')) {
+      const username = issue.user.login;
+
+      // Log the issue body for debugging
+      const issueBody = issue.body || "";
+      console.log('Full Issue Body:', issueBody);
+
+      // Default values
+      let projectArea = "N/A";
+      let dateCompleted = "N/A";
+      let typeOfContribution = "N/A";
+
+      // Improved parsing logic with more robust regex
+      const projectAreaMatch = issueBody.match(/Specify Area of Project \(1 - 5 words\):\n+(.+)/);
+      const dateCompletedMatch = issueBody.match(/Date of Completion:\n+(.+)/);
+      const typeOfContributionMatch = issueBody.match(/Specify the type of contribution \(e\.g\., Documentation, Community Building, etc\.\):\n+(.+)/);
+
+      if (projectAreaMatch) {
+        projectArea = projectAreaMatch[1].trim();
+        console.log('Project Area:', projectArea);
+      } else {
+        console.log('Project Area not found.');
+      }
+
+      if (dateCompletedMatch) {
+        dateCompleted = dateCompletedMatch[1].trim();
+        console.log('Date Completed:', dateCompleted);
+      } else {
+        console.log('Date Completed not found.');
+      }
+
+      if (typeOfContributionMatch) {
+        typeOfContribution = typeOfContributionMatch[1].trim();
+        console.log('Type of Contribution:', typeOfContribution);
+      } else {
+        console.log('Type of Contribution not found.');
+      }
+
+      // Assume the task description comes from the issue title
+      const taskCompleted = issue.title.replace('[Project]:', '').trim();
+
+      // Create a new row for the markdown table
+      const newRow = `| @${username} | ${taskCompleted} | ${projectArea} | ${dateCompleted} | ${typeOfContribution} |\n`;
+
+      const filePath = 'community-contributions.md';
+      const fileContents = fs.readFileSync(filePath, 'utf-8');
+
+      console.log('Original File Contents:');
+      console.log(fileContents);
+
+      // Append the new row to the existing content
+      const updatedContents = fileContents + newRow;
+
+      fs.writeFileSync(filePath, updatedContents);
+
+      console.log('New Row to Add:');
+      console.log(newRow);
+
+      console.log('Updated File Contents:');
+      console.log(updatedContents);
+
+      console.log(`New contribution added to ${filePath}`);
+    } else {
+      console.log('No "contribution" label found, skipping update.');
+    }
+  } catch (error) {
+    core.setFailed(error.message);
+  }
+})();


### PR DESCRIPTION
This proposed GitHub action will update the community-contributions.md file in the root of the directory after the creation of an issue using the included template. 

The functionality is tested and working at https://github.com/augurlabs/chaoss-action-bot ... Merging this PR will generate a need to immediately verify and test its functionality here. 