### PR TITLE
Updated WG list

### DIFF
--- a/chaoss-groups/working-groups.md
+++ b/chaoss-groups/working-groups.md
@@ -27,8 +27,6 @@ Context WGs are groups of people who share similar contexts related to open sour
 
 * [**OSPO**](https://github.com/chaoss/wg-ospo): The OSPO Metrics working group aims to advance how organizations understand the value that open source projects can provide as well as the value of these programs / initiatives. This is a joint effort between the CHAOSS project and the TODO Group.
 
-* [**Application Ecosystem**](https://github.com/chaoss/wg-app-ecosystem): This working group applies CHAOSS metrics in the context of an open-source app ecosystem. The mission of this working group is to build a base set of metrics that is focused on the needs of open source communities that are part of the FOSS app ecosystem.
-
 * [**University / Academic**](https://docs.google.com/document/d/1ZZg8vGQOgfhK6P6G8GQse6OaN3yb2Z_IQVyINa-0TZs/edit): The University working group is a joint effort between the CHAOSS project and the OSPO++ community that aims to create a set of recommendations for metrics related to university open source software, particularly as they relate to what might be seen as “success” for university leadership, faculty, students, and staff, keeping in mind that these actors may evaluate success differently. 
 
 * [**Science / Research**](https://github.com/chaoss/wg-science): The Science working group aims create a set of recommendations for metrics and models related to scientific open source communities. 
@@ -36,6 +34,12 @@ Context WGs are groups of people who share similar contexts related to open sour
 * [**Data Science**](https://github.com/chaoss/wg-data-science): We collaborate with data scientists and researchers to shape how we understand open source community health and make it easier for people to use CHAOSS tools, metrics, and metrics models to draw meaningful insights that they can use to improve open source project health using data science-based approaches.
 
 * [**UN Sustainable Development Goals (SDGs)**](https://docs.google.com/document/d/17VAYItNIw_i36mCUyBs1t9fEK_Ks1vjhOJFRfIA1CjM/edit?usp=sharing): The UN SDG working group focuses on using CHAOSS metrics to help understand the role of open source projects and their progress toward achieving the UN SDGs.
+
+* [**Funding Impact Measurement**](https://github.com/chaoss/wg-funding-impact): The funding WG aims to develop frameworks, metrics, and methodologies for measuring and understanding the impacts of funding on open source software development. 
+
+### Inactive Working Groups
+
+* [**Application Ecosystem**](https://github.com/chaoss/wg-app-ecosystem): This working group applies CHAOSS metrics in the context of an open-source app ecosystem. The mission of this working group is to build a base set of metrics that is focused on the needs of open source communities that are part of the FOSS app ecosystem.
 
 ## 3. Operations Working Groups
 
@@ -53,13 +57,5 @@ The Operations Working Groups are supporting the metrics discussions and are res
 * [**DEI Badging**](https://github.com/badging/): The DEI Badging working group focuses on our badging initiative that is meant to encourage open source projects and event organizers to obtain our Diversity, Equity, and Inclusion badges for the purposes of leadership self-reflection and self-improvement around the ways that they are centering DEI. 
 
 * [**Website**](https://docs.google.com/document/d/1p079Q75RZ2Duk-nX4osXY2v3oFjqF6-BTZG6XPx8iQ4/edit#heading=h.9qd11sbe2wiy): The Website working group focus on maintenance of CHAOSS Website. 
-
-* [**Design**](): Content will be added soon.
-
-* [**Technical Writing**]() Content will be added soon.
-
-* [**Disability/Accessibility**]() Content will be added soon.
-
-* [**Newcomer Experience**](): Content will be added soon.
 
 </details></span>


### PR DESCRIPTION
Updated to move App Ecosystem to inactive, add the funding WG, and remove some placeholder groups (we can add them back with the appropriate details later).