### PR TITLE
Updating new finance committee members

### DIFF
--- a/governance/finance-committee.md
+++ b/governance/finance-committee.md
@@ -15,9 +15,10 @@ Responsibilities:
 
 ### Members of the Finance Committee
 
-- Matt Germonprez
+- Anita Ihuman
 - Ray Paik
-- Georg Link
+- Sophia Vargas
+- Victoria Ottah
 
 ## Accepting Donations and Sponsorships
 


### PR DESCRIPTION
Adding Anita Ihuman, Sophia Vargas, and Victoria Ottah in place of Matt Germonprez & Georg Link who are stepping away.